### PR TITLE
Added IgnoreMissingObjects to ignore objects that were not found

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ func initConfig() {
 	viper.SetDefault("options.finderNumber", dth.DefaultFinderNumber)
 	viper.SetDefault("options.workerNumber", dth.DefaultWorkerNumber)
 	viper.SetDefault("options.includeMetadata", false)
+	viper.SetDefault("options.ignoreMissingObjects", false)
 
 	viper.BindEnv("srcType", "SOURCE_TYPE")
 	viper.BindEnv("srcBucket", "SRC_BUCKET")
@@ -135,14 +136,15 @@ func initConfig() {
 	}
 
 	options := &dth.JobOptions{
-		ChunkSize:          viper.GetInt("options.chunkSize"),
-		MultipartThreshold: viper.GetInt("options.multipartThreshold"),
-		MaxKeys:            viper.GetInt32("options.maxKeys"),
-		MessageBatchSize:   viper.GetInt("options.messageBatchSize"),
-		FinderDepth:        viper.GetInt("options.finderDepth"),
-		FinderNumber:       viper.GetInt("options.finderNumber"),
-		WorkerNumber:       viper.GetInt("options.workerNumber"),
-		IncludeMetadata:    viper.GetBool("options.includeMetadata"),
+		ChunkSize:            viper.GetInt("options.chunkSize"),
+		MultipartThreshold:   viper.GetInt("options.multipartThreshold"),
+		MaxKeys:              viper.GetInt32("options.maxKeys"),
+		MessageBatchSize:     viper.GetInt("options.messageBatchSize"),
+		FinderDepth:          viper.GetInt("options.finderDepth"),
+		FinderNumber:         viper.GetInt("options.finderNumber"),
+		WorkerNumber:         viper.GetInt("options.worker-Number"),
+		IncludeMetadata:      viper.GetBool("options.includeMetadata"),
+		IgnoreMissingObjects: viper.GetBool("options.ignoreMissingObjects"),
 	}
 
 	cfg = &dth.JobConfig{

--- a/dth/config.go
+++ b/dth/config.go
@@ -61,7 +61,7 @@ const (
 type JobOptions struct {
 	ChunkSize, MultipartThreshold, MessageBatchSize, FinderDepth, FinderNumber, WorkerNumber int
 	MaxKeys                                                                                  int32
-	IncludeMetadata                                                                          bool
+	IncludeMetadata, IgnoreMissingObjects                                                    bool
 }
 
 // JobConfig is General Job Info


### PR DESCRIPTION
*Issue* #3 

*Description of changes:*
Transfer an object only if it exists or the config `IgnoreMissingObjects` is disabled.
I found this is the easiest way instead of checking for the response codes of the transfer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
