### PR TITLE
fix: fix the illegal character code error when list objects

### DIFF
--- a/dth/client.go
+++ b/dth/client.go
@@ -608,7 +608,3 @@ func (c *S3Client) AbortMultipartUpload(ctx context.Context, key, uploadID *stri
 
 	return nil
 }
-
-func urlEncodePath(path string) string {
-	return (&url.URL{Path: path}).EscapedPath()
-}

--- a/dth/client.go
+++ b/dth/client.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -173,6 +174,7 @@ func (c *S3Client) listObjectFn(ctx context.Context, continuationToken, prefix, 
 		Prefix:    prefix,
 		MaxKeys:   maxKeys,
 		Delimiter: delimiter,
+		EncodingType: "url",
 	}
 
 	if *continuationToken != "" {
@@ -280,8 +282,12 @@ func (c *S3Client) ListObjects(ctx context.Context, continuationToken, prefix *s
 		if obj.StorageClass == "GLACIER" || obj.StorageClass == "DEEP_ARCHIVE" {
 			continue
 		}
+		escapedPrefix, err := url.QueryUnescape(*obj.Key)
+		if err != nil {
+			escapedPrefix = *obj.Key
+		}
 		result = append(result, &Object{
-			Key:  *obj.Key,
+			Key:  escapedPrefix,
 			Size: obj.Size,
 		})
 	}
@@ -601,4 +607,8 @@ func (c *S3Client) AbortMultipartUpload(ctx context.Context, key, uploadID *stri
 	}
 
 	return nil
+}
+
+func urlEncodePath(path string) string {
+	return (&url.URL{Path: path}).EscapedPath()
 }


### PR DESCRIPTION
*Issue #, if available:*
In some scenario, customer will meet issue during Finder job, with the error message:

```
2022/07/08 08:20:33 S3> Unable to list object in / - operation error S3: ListObjectsV2, https response error StatusCode: 200, RequestID: 62C7E8D1533755313638BA2A, HostID: , deserialization failed, failed to decode response body, XML syntax error on line 2: illegal character code U+0008
```

There are garbled characters in the client's object file name, such as some Arabic languages or the file name has been transcoded by **QueryEscape**.  At this time, you need to use the **QueryUnescape function** to restore the string transcoded by **QueryEscape**.

*Description of changes:*
Use url.QueryUnescape to preprocess the key of the object

```go
        escapedPrefix, err := url.QueryUnescape(*obj.Key)
        if err != nil {
            escapedPrefix = *obj.Key
        }
        result = append(result, &Object{
            Key:  escapedPrefix,
            Size: obj.Size,
        })
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
