### PR TITLE
fix:support access key rotation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -199,7 +199,6 @@ Supported types:
 		ctx := context.Background()
 
 		var job dth.Job
-
 		switch jobType {
 		case "Finder":
 			job = dth.NewFinder(ctx, cfg)
@@ -211,6 +210,7 @@ Supported types:
 			log.Fatalf("Unknown Job Type - %s. Type must be either Finder or Worker\n, please start again", jobType)
 
 		}
+		go dth.RunTicker(ctx, cfg)
 		job.Run(ctx)
 	},
 }

--- a/dth/common.go
+++ b/dth/common.go
@@ -33,6 +33,13 @@ var (
 	MB int = 1 << 20
 )
 
+// Global variables which are updated automatically every 02:00 a.m.
+// When calling a S3 API, the credentials of the client will be updated according to these two variables
+var (
+	SRC_CRED *S3Credentials
+	DST_CRED *S3Credentials
+)
+
 // Source is an interface represents a type of cloud storage services
 // type Source interface {
 // 	GetEndpointURL()

--- a/dth/job.go
+++ b/dth/job.go
@@ -116,6 +116,13 @@ func NewFinder(ctx context.Context, cfg *JobConfig) (f *Finder) {
 	srcClient := NewS3Client(ctx, cfg.SrcBucket, cfg.SrcPrefix, cfg.SrcPrefixList, cfg.SrcEndpoint, cfg.SrcRegion, cfg.SrcType, srcCred)
 	desClient := NewS3Client(ctx, cfg.DestBucket, cfg.DestPrefix, "", "", cfg.DestRegion, "Amazon_S3", desCred)
 
+	if srcClient != nil {
+		srcClient.isSrcClient = true
+	}
+
+	SRC_CRED = srcCred
+	DST_CRED = desCred
+
 	f = &Finder{
 		srcClient: srcClient,
 		desClient: desClient,
@@ -123,6 +130,36 @@ func NewFinder(ctx context.Context, cfg *JobConfig) (f *Finder) {
 		cfg:       cfg,
 	}
 	return
+}
+
+func RunTicker(ctx context.Context, cfg *JobConfig) {
+	t := &JobTicker{}
+	t.updateTimer()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("timer has been stopped")
+			t.timer.Stop()
+		case <-t.timer.C:
+			log.Printf("ticker update S3 Credentials")
+			updateCreds(ctx, cfg)
+			t.updateTimer()
+		}
+	}
+}
+
+func updateCreds(ctx context.Context, cfg *JobConfig) {
+	if cfg == nil {
+		log.Print("nil config")
+		return
+	}
+	sm, err := NewSecretService(ctx)
+	if err != nil {
+		log.Printf("Warning - Unable to load credentials, use default setting - %s\n", err.Error())
+	}
+	SRC_CRED = getCredentials(ctx, cfg.SrcCredential, cfg.SrcInCurrentAccount, sm)
+	DST_CRED = getCredentials(ctx, cfg.DestCredential, cfg.DestInCurrentAccount, sm)
+	log.Print("src_cred and dst_cred has been updated")
 }
 
 // Run is main execution function for Finder.
@@ -412,6 +449,13 @@ func NewWorker(ctx context.Context, cfg *JobConfig) (w *Worker) {
 	srcClient := NewS3Client(ctx, cfg.SrcBucket, cfg.SrcPrefix, cfg.SrcPrefixList, cfg.SrcEndpoint, cfg.SrcRegion, cfg.SrcType, srcCred)
 	desClient := NewS3Client(ctx, cfg.DestBucket, cfg.DestPrefix, "", "", cfg.DestRegion, "Amazon_S3", desCred)
 
+	if srcClient != nil {
+		srcClient.isSrcClient = true
+	}
+
+	SRC_CRED = srcCred
+	DST_CRED = desCred
+
 	return &Worker{
 		srcClient: srcClient,
 		desClient: desClient,
@@ -589,6 +633,13 @@ func (w *Worker) processResult(ctx context.Context, obj *Object, rh *string, res
 
 	log.Printf("----->Transferred 1 object %s with status %s\n", obj.Key, res.status)
 	w.db.UpdateItem(ctx, &obj.Key, res)
+
+	if res.status == "ERROR" {
+		if strings.Contains(res.err.Error(), "403") {
+			log.Printf("Authentication failed, will update credentials")
+			updateCreds(ctx, w.cfg)
+		}
+	}
 
 	if res.status == "DONE" || res.status == "CANCEL" {
 		w.sqs.DeleteMessage(ctx, rh)

--- a/dth/ticker.go
+++ b/dth/ticker.go
@@ -1,0 +1,34 @@
+package dth
+
+import (
+	"log"
+	"time"
+)
+
+const INTERVAL_PERIOD time.Duration = 24 * time.Hour
+
+const HOUR_TO_TICK int = 02
+const MINUTE_TO_TICK int = 00
+const SECOND_TO_TICK int = 00
+
+type JobTicker struct {
+	timer *time.Timer
+}
+
+func (t *JobTicker) updateTimer() {
+	nextTick := time.Date(time.Now().Year(), time.Now().Month(),
+		time.Now().Day(), HOUR_TO_TICK, MINUTE_TO_TICK, SECOND_TO_TICK, 0, time.Local)
+	if !nextTick.After(time.Now()) {
+		nextTick = nextTick.Add(INTERVAL_PERIOD)
+	}
+	log.Printf("next tick is:%v", nextTick)
+	diff := nextTick.Sub(time.Now())
+	if diff < 0 {
+		diff = INTERVAL_PERIOD
+	}
+	if t.timer == nil {
+		t.timer = time.NewTimer(diff)
+	} else {
+		t.timer.Reset(diff)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/aws/smithy-go v1.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
+	golang.org/x/sys v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-s3-data-replication-hub-plugin/issues/87

*Description of changes:*
1. add a timer that ticks on every 2:00 a.m.
2. add two global variables that stores the latest AK/SK, which will be updated on every tick
3. add an error handler which update the variables when receiving 403 error
4. add options change function when calling S3 apis

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
