### PR TITLE
enhancement: enable credentials for source bucket in current account

### DIFF
--- a/dth/job.go
+++ b/dth/job.go
@@ -77,29 +77,26 @@ func getCredentials(ctx context.Context, param string, inCurrentAccount bool, sm
 		noSignRequest: false,
 	}
 
-	// No need to do anything if inCurrentAccount is true
-	if !inCurrentAccount {
-		if param == "" {
-			// no credential is required.
-			cred.noSignRequest = true
-		} else {
-			credStr := sm.GetSecret(ctx, &param)
-			if credStr != nil {
-				credMap := make(map[string]string)
-				err := json.Unmarshal([]byte(*credStr), &credMap)
-				if err != nil {
-					log.Printf("Warning - Unable to parse the credentials string, please make sure the it is a valid json format. - %s\n", err.Error())
-				} else {
-					cred.accessKey = credMap["access_key_id"]
-					cred.secretKey = credMap["secret_access_key"]
-				}
-				// log.Println(*credStr)
-				// log.Println(credMap)
-			} else {
-				log.Printf("Credential parameter %s ignored, use default configuration\n", param)
-			}
-		}
-	}
+    if param == "" {
+        // no credential is required if not in current account
+        cred.noSignRequest = !inCurrentAccount
+    } else {
+        credStr := sm.GetSecret(ctx, &param)
+        if credStr != nil {
+            credMap := make(map[string]string)
+            err := json.Unmarshal([]byte(*credStr), &credMap)
+            if err != nil {
+                log.Printf("Warning - Unable to parse the credentials string, please make sure the it is a valid json format. - %s\n", err.Error())
+            } else {
+                cred.accessKey = credMap["access_key_id"]
+                cred.secretKey = credMap["secret_access_key"]
+            }
+            // log.Println(*credStr)
+            // log.Println(credMap)
+        } else {
+            log.Printf("Credential parameter %s ignored, use default configuration\n", param)
+        }
+    }
 	return cred
 }
 


### PR DESCRIPTION
For common scenarios, such as, establishing S3 transfer tasks for source buckets with KMS/CMK encryption, one must provide credentials with permissions to the KMS keys even if the source bucket is in the current account

*Issue* https://github.com/aws-samples/data-transfer-hub-cli/issues/14

*Description of changes:* Enable credentials extraction from passed configuration for source buckets in the current account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
